### PR TITLE
Remove chown from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
 FROM python:3.11-slim@sha256:edaf703dce209d774af3ff768fc92b1e3b60261e7602126276f9ceb0e3a96874
 
-RUN adduser --disabled-password loader
-USER loader
-
-# Define Git SHA build argument for sentry
+# Define Git SHA build argument for Sentry
 ARG git_sha="development"
 ENV GIT_SHA=$git_sha
 
-WORKDIR /home/loader
-
-COPY requirements.txt .
+COPY requirements/requirements.txt .
 RUN python -m pip install --requirement requirements.txt
 
-COPY --chown=loader:loader . .
+COPY pyproject.toml pyproject.toml
+COPY src/ src/
 RUN python -m pip install .
 
-CMD ["python", "-m", "loader"]
+RUN adduser --disabled-password loader
+USER loader
+
+CMD [ "python", "-m", "loader" ]


### PR DESCRIPTION
Was used to fix a permissions issue caused by the user being changed to early. 

Correct form copied from https://github.com/vipyrsec/bot/blob/930bd4b0134c4ab882212b2f83398eb82548e35a/Dockerfile