### PR TITLE
Remove unused dependency

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,4 +3,3 @@ pydantic-settings
 
 # PyPI integration
 letsbuilda-pypi>=5.0.0b3
-requests

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,9 +12,6 @@ certifi==2024.2.2
     # via
     #   httpcore
     #   httpx
-    #   requests
-charset-normalizer==3.3.2
-    # via requests
 h11==0.14.0
     # via httpcore
 httpcore==1.0.3
@@ -25,7 +22,6 @@ idna==3.6
     # via
     #   anyio
     #   httpx
-    #   requests
 letsbuilda-pypi==5.0.2
     # via -r requirements/requirements.in
 pydantic==2.6.1
@@ -36,8 +32,6 @@ pydantic-settings==2.2.0
     # via -r requirements/requirements.in
 python-dotenv==1.0.1
     # via pydantic-settings
-requests==2.31.0
-    # via -r requirements/requirements.in
 sniffio==1.3.0
     # via
     #   anyio
@@ -46,7 +40,5 @@ typing-extensions==4.9.0
     # via
     #   pydantic
     #   pydantic-core
-urllib3==2.2.1
-    # via requests
 xmltodict==0.13.0
     # via letsbuilda-pypi


### PR DESCRIPTION
`letsbuilda-pypi` has switched from `requests` to `httpx`, so `requests` is no longer required.

`httpx` is a required dependency of `letsbuilda-pypi`, so it doesn't need to be listed explicitly.