### PR TITLE
chore(pre-commit): use the Docker-based hook for hadolint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
   - repo: https://github.com/hadolint/hadolint
     rev: c3dc18df7a501f02a560a2cc7ba3c69a85ca01d3  # frozen: v2.13.1-beta
     hooks:
-      - id: hadolint
+      - id: hadolint-docker
         args:
           - --failure-threshold
           - error


### PR DESCRIPTION
This commit addresses the fact that the `hadolint` hook requires `hadolint` to be installed on the machine.
