### PR TITLE
[codex] Require explicit loader auth bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Dragonfly Loader
 
 An automated job to load new releases from the PyPI RSS feed into the [Dragonfly Mainframe](https://github.com/vipyrsec/dragonfly-mainframe).
+
+## Configuration
+
+The loader authenticates to Auth0 by default in all environments.
+
+Set `DISABLE_AUTH=true` only for local or test scenarios where the mainframe is
+also configured to bypass authentication.

--- a/src/loader/constants.py
+++ b/src/loader/constants.py
@@ -5,7 +5,6 @@ from os import getenv
 from pydantic_settings import BaseSettings
 
 GIT_SHA = getenv("GIT_SHA", "development")
-SKIP_AUTH = GIT_SHA in {"testing", "development"}
 
 
 class _Settings(BaseSettings):
@@ -21,6 +20,7 @@ class _Settings(BaseSettings):
     password: str = ""
 
     audience: str = "https://dragonfly.vipyrsec.com"
+    disable_auth: bool = False
 
 
 Settings = _Settings()

--- a/src/loader/loader.py
+++ b/src/loader/loader.py
@@ -3,7 +3,7 @@
 from httpx import Client
 from letsbuilda.pypi import PyPIServices
 
-from loader.constants import SKIP_AUTH, Settings
+from loader.constants import Settings
 
 
 def build_authorization_header(access_token: str) -> dict[str, str]:
@@ -47,7 +47,7 @@ def load_packages(packages: list[tuple[str, str]], *, http_client: Client, acces
 
 def main(*, http_client: Client, pypi_client: PyPIServices) -> None:
     """Run the loader."""
-    access_token = "DEVELOPMENT" if SKIP_AUTH else get_access_token(http_client=http_client)
+    access_token = "DEVELOPMENT" if Settings.disable_auth else get_access_token(http_client=http_client)
 
     packages = fetch_packages(pypi_client=pypi_client)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -25,6 +25,7 @@ ENV = {
     "CLIENT_ID": "test client id",
     "CLIENT_SECRET": "test client secret",
     "AUDIENCE": "test audience",
+    "DISABLE_AUTH": False,
 }
 
 
@@ -110,10 +111,37 @@ def test_main(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_pypi_client = Mock()
 
     fetch_packages_mock = Mock(return_value=mock_packages)
+    get_access_token_mock = Mock(return_value="abc")
     load_packages_mock = Mock()
     monkeypatch.setattr("loader.loader.fetch_packages", fetch_packages_mock)
+    monkeypatch.setattr("loader.loader.get_access_token", get_access_token_mock)
     monkeypatch.setattr("loader.loader.load_packages", load_packages_mock)
 
     loader.main(http_client=mock_http_client, pypi_client=mock_pypi_client)
+    get_access_token_mock.assert_called_once_with(http_client=mock_http_client)
     fetch_packages_mock.assert_any_call(pypi_client=mock_pypi_client)
+    load_packages_mock.assert_any_call(mock_packages, http_client=mock_http_client, access_token="abc")
+
+
+def test_main_disable_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that auth bypass requires explicit configuration."""
+    mock_packages = [
+        ("a", "1.0.0"),
+        ("b", "1.0.1"),
+    ]
+
+    mock_http_client = Mock()
+    mock_pypi_client = Mock()
+
+    fetch_packages_mock = Mock(return_value=mock_packages)
+    get_access_token_mock = Mock(return_value="should not be used")
+    load_packages_mock = Mock()
+    monkeypatch.setattr(Settings, "disable_auth", True)
+    monkeypatch.setattr("loader.loader.fetch_packages", fetch_packages_mock)
+    monkeypatch.setattr("loader.loader.get_access_token", get_access_token_mock)
+    monkeypatch.setattr("loader.loader.load_packages", load_packages_mock)
+
+    loader.main(http_client=mock_http_client, pypi_client=mock_pypi_client)
+
+    get_access_token_mock.assert_not_called()
     load_packages_mock.assert_any_call(mock_packages, http_client=mock_http_client, access_token="DEVELOPMENT")


### PR DESCRIPTION
## What changed
- removed the loader's implicit auth bypass based on `GIT_SHA`
- made auth bypass opt-in via `DISABLE_AUTH=true`
- updated tests so the default path always fetches a real Auth0 token
- documented the new behavior

## Why
Staging loader jobs started failing on March 31, 2026 after the mainframe rollout window.
Live cluster investigation showed:
- `dragonfly-loader` CronJob pods were failing with `401 Unauthorized` on `POST /batch/package`
- the scanner client stayed healthy but only logged `No job found`
- the live loader image defaulted `GIT_SHA` to `development`
- loader code treated `GIT_SHA=development` as `SKIP_AUTH`, so deployed jobs sent `Authorization: Bearer DEVELOPMENT`
- mainframe correctly rejected those requests

This change removes that implicit production footgun. Deployed workloads now authenticate by default unless auth bypass is explicitly enabled for local or test scenarios.

## Impact
- fixes staging queue ingestion once this image is deployed
- preserves local/test bypass capability through explicit configuration
- reduces the risk of silent auth-disable behavior from image defaults

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest`
- live staging verification before the fix identified:
  - repeated `401` responses from `mainframe.dragonfly.svc.cluster.local:8000/batch/package`
  - loader image environment defaulting `GIT_SHA` to `development`
  - direct authenticated probe to mainframe with a freshly minted loader token returned `200`
