### PR TITLE
feat: migrate loader staging auth to Cloudflare Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@ An automated job to load new releases from the PyPI RSS feed into the [Dragonfly
 
 ## Configuration
 
-The loader authenticates to Auth0 by default in all environments.
+The loader authenticates to a Cloudflare Access protected Dragonfly endpoint by
+default in all environments.
+
+Required runtime settings:
+
+- `BASE_URL`
+- `CF_ACCESS_CLIENT_ID`
+- `CF_ACCESS_CLIENT_SECRET`
 
 Set `DISABLE_AUTH=true` only for local or test scenarios where the mainframe is
 also configured to bypass authentication.
+
+For staging, `BASE_URL` should be the public protected hostname rather than an
+in-cluster origin, for example `https://dragonfly-staging.vipyrsec.com`.

--- a/src/loader/constants.py
+++ b/src/loader/constants.py
@@ -11,15 +11,8 @@ class _Settings(BaseSettings):
     """Settings for the Dragonfly Loader."""
 
     base_url: str = "https://dragonfly.vipyrsec.com"
-    auth0_domain: str = "vipyrsec.us.auth0.com"
-
-    client_id: str = ""
-    client_secret: str = ""
-
-    username: str = ""
-    password: str = ""
-
-    audience: str = "https://dragonfly.vipyrsec.com"
+    cf_access_client_id: str = ""
+    cf_access_client_secret: str = ""
     disable_auth: bool = False
 
 

--- a/src/loader/loader.py
+++ b/src/loader/loader.py
@@ -6,26 +6,12 @@ from letsbuilda.pypi import PyPIServices
 from loader.constants import Settings
 
 
-def build_authorization_header(access_token: str) -> dict[str, str]:
-    """Build authorization headers using the access token."""
-    return {"Authorization": "Bearer " + access_token}
-
-
-def get_access_token(*, http_client: Client) -> str:
-    """Get an access token from Auth0."""
-    payload = {
-        "client_id": Settings.client_id,
-        "client_secret": Settings.client_secret,
-        "username": Settings.username,
-        "password": Settings.password,
-        "audience": Settings.audience,
-        "grant_type": "password",
+def build_access_headers() -> dict[str, str]:
+    """Build Cloudflare Access service-token headers."""
+    return {
+        "CF-Access-Client-Id": Settings.cf_access_client_id,
+        "CF-Access-Client-Secret": Settings.cf_access_client_secret,
     }
-
-    res = http_client.post(f"https://{Settings.auth0_domain}/oauth/token", json=payload)
-    res.raise_for_status()
-    json = res.json()
-    return json["access_token"]  # type: ignore[no-any-return]
 
 
 def fetch_packages(*, pypi_client: PyPIServices) -> list[tuple[str, str]]:
@@ -36,10 +22,9 @@ def fetch_packages(*, pypi_client: PyPIServices) -> list[tuple[str, str]]:
     return [(package.title, package.version) for package in packages if package.version is not None]
 
 
-def load_packages(packages: list[tuple[str, str]], *, http_client: Client, access_token: str) -> None:
-    """Load all of the given packages into the Dragonfly API, using the given HTTP session and access token."""
+def load_packages(packages: list[tuple[str, str]], *, http_client: Client, headers: dict[str, str]) -> None:
+    """Load all of the given packages into the Dragonfly API."""
     payload = [{"name": name, "version": version} for name, version in packages]
-    headers = build_authorization_header(access_token)
 
     res = http_client.post(f"{Settings.base_url}/batch/package", json=payload, headers=headers)
     res.raise_for_status()
@@ -47,8 +32,8 @@ def load_packages(packages: list[tuple[str, str]], *, http_client: Client, acces
 
 def main(*, http_client: Client, pypi_client: PyPIServices) -> None:
     """Run the loader."""
-    access_token = "DEVELOPMENT" if Settings.disable_auth else get_access_token(http_client=http_client)
+    headers = {} if Settings.disable_auth else build_access_headers()
 
     packages = fetch_packages(pypi_client=pypi_client)
 
-    load_packages(packages, http_client=http_client, access_token=access_token)
+    load_packages(packages, http_client=http_client, headers=headers)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -19,12 +19,8 @@ class MockPackage:
 
 ENV = {
     "BASE_URL": "https://example.com",
-    "AUTH0_DOMAIN": "example-auth.com",
-    "USERNAME": "test username",
-    "PASSWORD": "test password",
-    "CLIENT_ID": "test client id",
-    "CLIENT_SECRET": "test client secret",
-    "AUDIENCE": "test audience",
+    "CF_ACCESS_CLIENT_ID": "test client id",
+    "CF_ACCESS_CLIENT_SECRET": "test client secret",
     "DISABLE_AUTH": False,
 }
 
@@ -36,33 +32,14 @@ def mock_env(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(Settings, k.lower(), v)
 
 
-def test_build_authorization_header() -> None:
-    """Test that building authorization header works properly."""
-    expected = {"Authorization": "Bearer token"}
-    actual = loader.build_authorization_header("token")
-
-    assert expected == actual
-
-
-def test_get_access_token() -> None:
-    """Test that getting access token works properly."""
-    json_return_mock = {"access_token": "abc"}
-    attrs = {"post.return_value.json.return_value": json_return_mock}
-    mock_client = Mock(**attrs)
-    access_token = loader.get_access_token(http_client=mock_client)
-
-    expected_url = f"https://{ENV['AUTH0_DOMAIN']}/oauth/token"
+def test_build_access_headers() -> None:
+    """Test that building Cloudflare Access headers works properly."""
     expected_payload = {
-        "client_id": ENV["CLIENT_ID"],
-        "client_secret": ENV["CLIENT_SECRET"],
-        "username": ENV["USERNAME"],
-        "password": ENV["PASSWORD"],
-        "audience": ENV["AUDIENCE"],
-        "grant_type": "password",
+        "CF-Access-Client-Id": ENV["CF_ACCESS_CLIENT_ID"],
+        "CF-Access-Client-Secret": ENV["CF_ACCESS_CLIENT_SECRET"],
     }
 
-    mock_client.post.assert_called_with(expected_url, json=expected_payload)
-    assert access_token == "abc"
+    assert loader.build_access_headers() == expected_payload
 
 
 def test_fetch_packages() -> None:
@@ -71,8 +48,8 @@ def test_fetch_packages() -> None:
         MockPackage(title="a", version="1.0.0"),
         MockPackage(title="b", version="1.0.1"),
     ]
-    attrs = {"get_rss_feed.return_value": mock_packages}
-    mock_pypi_client = Mock(**attrs)
+    mock_pypi_client = Mock()
+    mock_pypi_client.get_rss_feed.return_value = mock_packages
 
     actual = loader.fetch_packages(pypi_client=mock_pypi_client)
     expected = [("a", "1.0.0"), ("b", "1.0.1")]
@@ -89,14 +66,17 @@ def test_load_packages() -> None:
         ("b", "1.0.1"),
     ]
 
-    loader.load_packages(mock_packages, http_client=mock_client, access_token="test access token")
+    headers: dict[str, str] = {
+        "CF-Access-Client-Id": str(ENV["CF_ACCESS_CLIENT_ID"]),
+        "CF-Access-Client-Secret": str(ENV["CF_ACCESS_CLIENT_SECRET"]),
+    }
+    loader.load_packages(mock_packages, http_client=mock_client, headers=headers)
 
     expected_payload = [{"name": name, "version": version} for name, version in mock_packages]
-    expected_headers = {"Authorization": "Bearer test access token"}
     mock_client.post.assert_called_once_with(
         f"{ENV['BASE_URL']}/batch/package",
         json=expected_payload,
-        headers=expected_headers,
+        headers=headers,
     )
 
 
@@ -111,16 +91,28 @@ def test_main(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_pypi_client = Mock()
 
     fetch_packages_mock = Mock(return_value=mock_packages)
-    get_access_token_mock = Mock(return_value="abc")
+    build_access_headers_mock = Mock(
+        return_value={
+            "CF-Access-Client-Id": "abc",
+            "CF-Access-Client-Secret": "def",
+        },
+    )
     load_packages_mock = Mock()
     monkeypatch.setattr("loader.loader.fetch_packages", fetch_packages_mock)
-    monkeypatch.setattr("loader.loader.get_access_token", get_access_token_mock)
+    monkeypatch.setattr("loader.loader.build_access_headers", build_access_headers_mock)
     monkeypatch.setattr("loader.loader.load_packages", load_packages_mock)
 
     loader.main(http_client=mock_http_client, pypi_client=mock_pypi_client)
-    get_access_token_mock.assert_called_once_with(http_client=mock_http_client)
+    build_access_headers_mock.assert_called_once_with()
     fetch_packages_mock.assert_any_call(pypi_client=mock_pypi_client)
-    load_packages_mock.assert_any_call(mock_packages, http_client=mock_http_client, access_token="abc")
+    load_packages_mock.assert_any_call(
+        mock_packages,
+        http_client=mock_http_client,
+        headers={
+            "CF-Access-Client-Id": "abc",
+            "CF-Access-Client-Secret": "def",
+        },
+    )
 
 
 def test_main_disable_auth(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -134,14 +126,14 @@ def test_main_disable_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_pypi_client = Mock()
 
     fetch_packages_mock = Mock(return_value=mock_packages)
-    get_access_token_mock = Mock(return_value="should not be used")
+    build_access_headers_mock = Mock(return_value={"should": "not be used"})
     load_packages_mock = Mock()
     monkeypatch.setattr(Settings, "disable_auth", True)
     monkeypatch.setattr("loader.loader.fetch_packages", fetch_packages_mock)
-    monkeypatch.setattr("loader.loader.get_access_token", get_access_token_mock)
+    monkeypatch.setattr("loader.loader.build_access_headers", build_access_headers_mock)
     monkeypatch.setattr("loader.loader.load_packages", load_packages_mock)
 
     loader.main(http_client=mock_http_client, pypi_client=mock_pypi_client)
 
-    get_access_token_mock.assert_not_called()
-    load_packages_mock.assert_any_call(mock_packages, http_client=mock_http_client, access_token="DEVELOPMENT")
+    build_access_headers_mock.assert_not_called()
+    load_packages_mock.assert_any_call(mock_packages, http_client=mock_http_client, headers={})


### PR DESCRIPTION
## Summary
- replace loader Auth0 token acquisition with Cloudflare Access service-token headers
- remove deprecated loader runtime settings and document the Cloudflare-only contract
- update loader tests to cover the Cloudflare header path and auth bypass behavior

## Validation
- `env UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run pytest`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run pyright`

Closes #97
